### PR TITLE
Remove legacy transform

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -3,11 +3,8 @@
  * Module dependencies.
  */
 
-var transform = require('segmentio-transform-legacy');
 var integration = require('segmentio-integration');
-var ValidationError = integration.errors.Validation;
 var url = require('url');
-var ms = require('ms');
 
 /**
  * Expose `Webhooks`
@@ -15,8 +12,7 @@ var ms = require('ms');
 
 var Webhooks = module.exports = integration('Webhooks')
   .channels(['server', 'mobile', 'client'])
-  .timeout('3s')
-  .retries(1);
+  .timeout('3s');
 
 /**
  * Ensure `globalHook` is a url.
@@ -50,28 +46,18 @@ Webhooks.prototype.screen = request;
 
 function request(message, fn){
   var json = message.json();
-  var data;
-  var err;
-
   json.options = json.options || json.context;
-
-  try {
-    data = transform(json);
-  } catch (e) {
-    err = e;
-  }
-
-  if (err) return fn(err);
-
   return this
   .post(this.settings.globalHook)
   .type('json')
-  .send(data)
+  .send(json)
   .end(this.handle(fn));
 }
 
 /**
  * Check if the given `value` is a valid url.
+ *
+ * TODO: this should be checked when the integration is saved.
  *
  * @param {Mixed} value
  * @return {Boolean}

--- a/package.json
+++ b/package.json
@@ -13,8 +13,7 @@
     "test": "make test"
   },
   "dependencies": {
-    "segmentio-integration": "^3.0.5",
-    "segmentio-transform-legacy": "^2.0.2"
+    "segmentio-integration": "^3.0.5"
   },
   "devDependencies": {
     "express": "~3.2.6",

--- a/test/index.js
+++ b/test/index.js
@@ -31,8 +31,7 @@ describe('Webhooks', function(){
     test
       .name('Webhooks')
       .channels(['server', 'mobile', 'client'])
-      .timeout('3s')
-      .retries(1)
+      .timeout('3s');
   });
 
   describe('.validate()', function(){


### PR DESCRIPTION
I noticed some awkward properties when debugging the webhook queue delays with request bin, turned out to be the legacy transform stuff. It adds `sessionId`, `providers` and upper cases the action. Think we can just get rid of it? 

http://requestb.in/1f3hbso1?inspect

```json
{
  "anonymousId":"1381093812",
  "channel":"server",
  "context":{
    "library":{
      "name":"analytics-node",
      "version":"1.1.1"
    }
  },
  "email":"gjj391@gmail.com",
  "integrations":{

  },
  "messageId":"6nl1bhu3",
  "originalTimestamp":"2015-02-11T21:57:56.439Z",
  "projectId":"dKjtaMxTxn",
  "receivedAt":"2015-02-11T21:58:05.996Z",
  "sentAt":"2015-02-11T21:58:06.441Z",
  "timestamp":"2015-02-11T21:57:56.439Z",
  "type":"identify",
  "version":2,
  "writeKey":"WGJPTZ6tLl",
  "options":{
    "library":"analytics-node",
    "providers":{

    }
  },
  "action":"Identify",
  "sessionId":"1381093812"
}
```

@calvinfo @yields 