### PR TITLE
Convert body text to UTF-8 before encrypting for signature

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -47,10 +47,6 @@ Webhooks.prototype.screen = request;
 
 function request(message, fn){
   var body = JSON.stringify(message.json());
-  
-  //convert body to UTF-8 using method described here
-  //http://ecmanaut.blogspot.ca/2006/07/encoding-decoding-utf8-in-javascript.html
-  body = unescape(encodeURIComponent(body))
 
   var req = this
     .post(this.settings.globalHook)
@@ -63,7 +59,7 @@ function request(message, fn){
   if (typeof sharedSecret === 'string' && sharedSecret.length) {
     var digest = crypto
       .createHmac('sha1', sharedSecret)
-      .update(body)
+      .update(body, 'utf8')
       .digest('hex');
 
     req.set('X-Signature', digest);

--- a/lib/index.js
+++ b/lib/index.js
@@ -47,6 +47,11 @@ Webhooks.prototype.screen = request;
 
 function request(message, fn){
   var body = JSON.stringify(message.json());
+  
+  //convert body to UTF-8 using method described here
+  //http://ecmanaut.blogspot.ca/2006/07/encoding-decoding-utf8-in-javascript.html
+  body = unescape(encodeURIComponent(body))
+
   var req = this
     .post(this.settings.globalHook)
     .type('json')


### PR DESCRIPTION
Hi!  

At Windsor Circle we have started testing the Signature based authentication and found that our (python-based) encryption didn't match the webhooks signature for JSON text that contained unicode characters.  This is due to JavaScripts strange default handling of unicode where each code point is treated as a separate character. If we treat all strings as UTF-8, this solves this problem for strings containing unicode, without breaking anything for non-unicode strings.

An example bad request:

```
'{"anonymousId":"f9ad2ff3-77e8-47d7-a3fe-339e9bf7052c","channel":"client","context":{"ip":"66.57.36.207","library":{"name":"analytics.js","version":"2.10.0"},"page":{"path":"/products/212781","referrer":"https://smitham-group8975.myshopify.com/collections/frontpage/products/public-key-holistic-budgetary-management","search":"","title":"Acoustic Research ARRX18G Xsight Touch Universal Remote Control – BDHE","url":"http://smitham-group8975.myshopify.com/products/212781"},"userAgent":"Mozilla/5.0 (Macintosh; Intel Mac OS X 10_10_5) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/45.0.2454.85 Safari/537.36"},"event":"Viewed Product","integrations":{},"messageId":"ajs-0c37552eac671297076879cffcb6a772","originalTimestamp":"2015-09-15T18:51:19.900Z","projectId":"jGdE3nzNlv","properties":{"available":true,"collections":["Frontpage"],"id":"91563458","name":"Acoustic Research ARRX18G Xsight Touch Universal Remote Control","options":["Title"],"optionsCount":1,"price":"24999","priceMax":"24999","priceMin":"24999","priceVaries":"false","tag":[""],"type":"Home Theater > Power Amplifiers> Headphone Amplifiers","url":"/products/212781","vendor":"Acoustic Research"},"receivedAt":"2015-09-15T18:51:19.937Z","sentAt":"2015-09-15T18:51:19.902Z","timestamp":"2015-09-15T18:51:19.935Z","type":"track","userId":null,"version":2}'
```

This produces `b64c8bc284dbcc6962d906188156cb5959437aba` when run through the supplied JS code, whereas our python code produces `e143ca1cfb062fb0aec746ecc004e6422b570d38` using our key (obviously the exact values will vary dependent on key).  Values match up fine when unicode characters are not present

This is because of the unicode character in `Acoustic Research ARRX18G Xsight Touch Universal Remote Control – BDHE`.  When that dash at the end is removed, the digests match. 

The python code we're using is below

```python
import hmac
import hashlib
event = '<event string>'
key ='<our secret>'

encryption = hmac.new(key, event, hashlib.sha1)
print(encryption.hexdigest())
```

More on JavaScript weirdness with unicode:

https://mathiasbynens.be/notes/javascript-encoding
https://mathiasbynens.be/notes/javascript-unicode
