### PR TITLE
Add ability to send to multiple webhooks

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -7,6 +7,7 @@
 var crypto = require('crypto');
 var integration = require('segmentio-integration');
 var url = require('url');
+var Batch = require('batch');
 
 /**
  * Expose `Webhooks`
@@ -16,15 +17,6 @@ var Webhooks = module.exports = integration('Webhooks')
   .channels(['server', 'mobile', 'client'])
   .timeout('3s')
   .retries(1);
-
-/**
- * Ensure `globalHook` is a url.
- */
-
-Webhooks.ensure(function(_, settings){
-  if (isUrl(settings.globalHook)) return;
-  return this.invalid('"globalHook" must be a valid url, got "%s"', settings.globalHook);
-});
 
 /**
  * Expose our methods
@@ -45,27 +37,58 @@ Webhooks.prototype.screen = request;
  * @api private
  */
 
-function request(message, fn){
+function request(message, done){
   var body = JSON.stringify(message.json());
-
-  var req = this
-    .post(this.settings.globalHook)
-    .type('json')
-    .send(body)
-    .parse(ignore);
-
   var sharedSecret = this.settings.sharedSecret;
+  var digest;
+  var self = this;
 
   if (typeof sharedSecret === 'string' && sharedSecret.length) {
-    var digest = crypto
+    digest = crypto
       .createHmac('sha1', sharedSecret)
       .update(body, 'utf8')
       .digest('hex');
-
-    req.set('X-Signature', digest);
   }
 
-  req.end(this.handle(fn));
+  var batch = new Batch();
+  batch.throws(false);
+
+  var hooks;
+  if (self.settings.hooks === undefined || self.settings.hooks.length == 0) {
+    hooks = [self.settings.globalHook];
+  } else {
+    hooks = self.settings.hooks;
+  }
+
+  var validHooks = hooks.filter(isUrl);
+  validHooks.forEach(function(hook) {
+    batch.push(function(done) {
+      var req = self
+        .post(hook)
+        .type('json')
+        .send(body)
+        .parse(ignore);
+
+      if (digest) {
+        req.set('X-Signature', digest);
+      }
+
+      req.end(self.handle(done));
+    });
+  });
+
+  batch.end(function(errors, results) {
+    var realErrors = errors.filter(function(error) {
+      return error !== null;
+    });
+    // Only fail if all the webhooks were down.
+    if (realErrors.length === validHooks.length) {
+      var error = new Error('Batch failed');
+      error.errors = realErrors;
+      return done(error, results);
+    }
+    done(null, results);
+  });
 }
 
 /**

--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "test": "make test"
   },
   "dependencies": {
-    "segmentio-integration": "^3.0.5"
+    "segmentio-integration": "^3.0.5",
+    "batch": "^0.5.2"
   },
   "devDependencies": {
     "express": "~3.2.6",


### PR DESCRIPTION
For now, this respects the `globalHook` setting. Once we deploy this, we
can migrate existing users to `hooks` and remove `globalHook` from the
db and I'll follow up with a PR to remove `globalHook` from the
integration as well.