### PR TITLE
Adding in-memory rate-limiting

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -8,6 +8,8 @@ var crypto = require('crypto');
 var integration = require('segmentio-integration');
 var url = require('url');
 var Batch = require('batch');
+var LRU = require('lru-cache');
+var ms = require('ms');
 
 /**
  * Expose `Webhooks`
@@ -19,6 +21,17 @@ var Webhooks = module.exports = integration('Webhooks')
   .retries(1);
 
 /**
+ * Add an in-memory cache for now
+ */
+
+Webhooks.prototype.initialize = function(){
+  this.cache = new LRU({
+    max: 10000,
+    maxAge: ms('3m')
+  });
+};
+
+/**
  * Expose our methods
  */
 
@@ -28,6 +41,15 @@ Webhooks.prototype.group = request;
 Webhooks.prototype.track = request;
 Webhooks.prototype.page = request;
 Webhooks.prototype.screen = request;
+
+/**
+ * Return whether the url is over or under limit
+ */
+
+Webhooks.prototype.allowed = function(url){
+  var errors = this.cache.peek(url);
+  return !errors || (errors < 25);
+}
 
 /**
  * Request.
@@ -42,6 +64,7 @@ function request(message, done){
   var sharedSecret = this.settings.sharedSecret;
   var digest;
   var self = this;
+  var cache = this.cache;
 
   if (typeof sharedSecret === 'string' && sharedSecret.length) {
     digest = crypto
@@ -54,29 +77,44 @@ function request(message, done){
   batch.throws(false);
 
   var hooks = self.settings.hooks.slice(0, 5);
-  var validHooks = hooks.filter(isUrl);
+
+  var validHooks = hooks
+    .filter(isUrl)
+    .filter(this.allowed.bind(this))
+
   if (validHooks.length === 0) {
     return done();
   }
-  validHooks.forEach(function(hook) {
-    batch.push(function(done) {
+
+  var errors = [];
+  var results = [];
+
+  validHooks.forEach(function(hook, i){
+    batch.push(function(done){
       var req = self
         .post(hook)
         .type('json')
         .send(body)
         .parse(ignore);
 
-      if (digest) {
-        req.set('X-Signature', digest);
-      }
+      if (digest) req.set('X-Signature', digest);
 
-      req.end(self.handle(done));
+      req.end(self.handle(function(err, res){
+        if (err) {
+          var errCount = cache.peek(hook);
+          errCount = errCount + 1 || 1;
+          cache.set(hook, errCount);
+        }
+        errors[i] = err;
+        results[i] = res;
+        done();
+      }));
     });
   });
 
-  batch.end(function(errors, results) {
-    var realErrors = errors.filter(function(error) {
-      return error !== null;
+  batch.end(function(){
+    var realErrors = errors.filter(function(error){
+      return error;
     });
     // Only fail if all the webhooks were down.
     if (realErrors.length === validHooks.length) {

--- a/package.json
+++ b/package.json
@@ -13,8 +13,10 @@
     "test": "make test"
   },
   "dependencies": {
-    "segmentio-integration": "^3.0.5",
-    "batch": "^0.5.2"
+    "batch": "^0.5.2",
+    "lru-cache": "^4.0.0",
+    "ms": "^0.7.1",
+    "segmentio-integration": "^3.0.5"
   },
   "devDependencies": {
     "express": "~3.2.6",


### PR DESCRIPTION
Here's a simple fix to add in-memory rate limiting. It also
fixes behavior where multiple invalid webhooks are down.